### PR TITLE
Fix rotating while at checkpoint after attack state

### DIFF
--- a/scripts/animations/attack_animations.gd
+++ b/scripts/animations/attack_animations.gd
@@ -162,7 +162,7 @@ func receive_cannot_attack_again() -> void:
 
 func receive_attack_finished() -> void:
 	_level = 1
-	if _intend_to_stop_attacking:
+	if _intend_to_stop_attacking and attacking:
 		attacking_finished.emit()
 		stop_attacking()
 

--- a/scripts/player/player_attack_state.gd
+++ b/scripts/player/player_attack_state.gd
@@ -56,7 +56,7 @@ func process_player():
 
 
 func exit():
-	player.movement_component.can_move = true
+	player.attack_component.interrupt_attack()
 
 
 func check_for_dizzy_finisher() -> bool:

--- a/scripts/player/player_attack_state.gd
+++ b/scripts/player/player_attack_state.gd
@@ -56,6 +56,7 @@ func process_player():
 
 
 func exit():
+	player.movement_component.can_move = true
 	player.attack_component.interrupt_attack()
 
 


### PR DESCRIPTION
Also for some reason attack finished (signal by animator?) still calling, so add additional check for if we attacking. May be fixable on animator side.

For reproduce bug reproduce just: 

1. Get close to checkpoint.
2. Attack.
3. Interrupt attack by interact with checkpoint(press E).
4. Now you can rotate using move buttons(WASD).

It also true for interrupting attack by death(fall) so you be able to rotate while get up from checkpoint.