### PR TITLE
Fix backstub

### DIFF
--- a/scenes/components/PlayerRotationComponent.tscn
+++ b/scenes/components/PlayerRotationComponent.tscn
@@ -2,6 +2,5 @@
 
 [ext_resource type="Script" path="res://scripts/components/rotation/player_rotation_component.gd" id="1_fulxd"]
 
-[node name="PlayerRotationComponent" type="Node3D" node_paths=PackedStringArray("entity")]
+[node name="PlayerRotationComponent" type="Node3D"]
 script = ExtResource("1_fulxd")
-entity = NodePath("")

--- a/scenes/entities/Player.tscn
+++ b/scenes/entities/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=3 uid="uid://dujukbu10vbmm"]
+[gd_scene load_steps=44 format=3 uid="uid://dujukbu10vbmm"]
 
 [ext_resource type="Script" path="res://scripts/entities/player.gd" id="1_lgfyt"]
 [ext_resource type="Script" path="res://scripts/player/player_state_machine.gd" id="2_4ql4h"]
@@ -16,9 +16,11 @@
 [ext_resource type="Script" path="res://scripts/player/player_block_state.gd" id="9_t1v34"]
 [ext_resource type="PackedScene" uid="uid://b616qwvblkmpo" path="res://scenes/components/BlockComponent.tscn" id="10_hjlwj"]
 [ext_resource type="Script" path="res://scripts/player/player_parry_state.gd" id="10_xd0pu"]
-[ext_resource type="Script" path="res://scripts/player/player_backstab_state.gd" id="11_i0t64"]
 [ext_resource type="Script" path="res://scripts/player/player_dizzy_state/player_dizzy_finisher_from_parry_state.gd" id="12_ull0x"]
+[ext_resource type="Script" path="res://scripts/player/player_backstab_state/player_backstab_attack_state.gd" id="16_nyfh7"]
+[ext_resource type="Script" path="res://scripts/player/player_backstab_state/player_backstab_state.gd" id="16_sn4wl"]
 [ext_resource type="Script" path="res://scripts/player/player_dizzy_state/player_dizzy_finisher_state.gd" id="16_vyrl8"]
+[ext_resource type="Script" path="res://scripts/player/player_backstab_state/player_backstab_prepare_state.gd" id="17_5scrx"]
 [ext_resource type="Script" path="res://scripts/player/player_dizzy_state/player_dizzy_finisher_from_damage_state.gd" id="18_hlp8w"]
 [ext_resource type="Script" path="res://scripts/player/player_parried_by_enemy_state.gd" id="19_24iu4"]
 [ext_resource type="Script" path="res://scripts/player/player_parried_enemy_hit_state.gd" id="20_1olui"]
@@ -245,14 +247,25 @@ dizzy_finisher_state = NodePath("../DizzyFinisher")
 sfx = NodePath("../../CharacterModel/AudioManager/Parry")
 player = NodePath("../..")
 
-[node name="Backstab" type="Node" parent="StateMachine" node_paths=PackedStringArray("dodge_state", "jump_state", "attack_state", "block_state", "parry_state", "player")]
-script = ExtResource("11_i0t64")
-dodge_state = NodePath("../Dodge")
-jump_state = NodePath("../Jump")
-attack_state = NodePath("../Attack")
-block_state = NodePath("../Block")
-parry_state = NodePath("../Parry")
+[node name="Backstab" type="Node" parent="StateMachine" node_paths=PackedStringArray("prepare_state", "attack_state", "player")]
+script = ExtResource("16_sn4wl")
+prepare_state = NodePath("Prepare")
+attack_state = NodePath("Attack")
 player = NodePath("../..")
+
+[node name="Prepare" type="Node" parent="StateMachine/Backstab" node_paths=PackedStringArray("dodge_state", "jump_state", "attack_state", "block_state", "parry_state", "backstab_attack_state", "player")]
+script = ExtResource("17_5scrx")
+dodge_state = NodePath("../../Dodge")
+jump_state = NodePath("../../Jump")
+attack_state = NodePath("../../Attack")
+block_state = NodePath("../../Block")
+parry_state = NodePath("../../Parry")
+backstab_attack_state = NodePath("../Attack")
+player = NodePath("../../..")
+
+[node name="Attack" type="Node" parent="StateMachine/Backstab" node_paths=PackedStringArray("player")]
+script = ExtResource("16_nyfh7")
+player = NodePath("../../..")
 
 [node name="DizzyFinisher" type="Node" parent="StateMachine" node_paths=PackedStringArray("from_parry", "from_damage", "player")]
 script = ExtResource("16_vyrl8")

--- a/scripts/camera_controller/camera_controller_normal_state.gd
+++ b/scripts/camera_controller/camera_controller_normal_state.gd
@@ -16,7 +16,7 @@ func process_camera() -> void:
 	
 	if Globals.backstab_system.backstab_victim != null and \
 	player.state_machine.current_state is PlayerBackstabState and \
-	player.attack_component.attacking:
+	player.state_machine.current_state.current_state is PlayerBackstabAttackState:
 		parent_state.change_state(
 			backstab_state
 		)

--- a/scripts/player/player_attack_state.gd
+++ b/scripts/player/player_attack_state.gd
@@ -20,10 +20,7 @@ func enter():
 	
 	player.movement_component.can_move = false
 	
-	if parent_state.previous_state is PlayerBackstabState or \
-	Globals.backstab_system.backstab_victim != null:
-		player.attack_component.thrust()
-	elif parent_state.previous_state is PlayerBlockState:
+	if parent_state.previous_state is PlayerBlockState:
 		player.attack_component.attack(false)
 	else:
 		player.attack_component.attack()

--- a/scripts/player/player_backstab_state/player_backstab_attack_state.gd
+++ b/scripts/player/player_backstab_state/player_backstab_attack_state.gd
@@ -1,0 +1,16 @@
+class_name PlayerBackstabAttackState
+extends PlayerStateMachine
+
+func _ready():
+	super._ready()
+
+
+func enter():
+	player.rotation_component.rotate_towards_target = true
+	player.attack_component.thrust()
+	player.hitbox_component.enabled = false
+	player.movement_component.can_move = false
+
+func exit():
+	player.hitbox_component.enabled = true
+	player.movement_component.can_move = true

--- a/scripts/player/player_backstab_state/player_backstab_prepare_state.gd
+++ b/scripts/player/player_backstab_state/player_backstab_prepare_state.gd
@@ -1,4 +1,4 @@
-class_name PlayerBackstabState
+class_name PlayerBackstabPrepareState
 extends PlayerStateMachine
 
 
@@ -7,14 +7,16 @@ extends PlayerStateMachine
 @export var attack_state: PlayerAttackState
 @export var block_state: PlayerBlockState
 @export var parry_state: PlayerParryState
+@export var backstab_attack_state: PlayerBackstabAttackState
 
+var main_state : PlayerStateMachine
 
 func _ready():
 	super._ready()
 
 
 func enter():
-	pass
+	main_state = parent_state.parent_state
 
 
 func process_player():
@@ -26,30 +28,29 @@ func process_player():
 	
 	
 	if Input.is_action_just_pressed("run"):
-		parent_state.change_state(dodge_state)
+		main_state.change_state(dodge_state)
 		return
 	
 	if Input.is_action_just_pressed("jump") and \
 	player.is_on_floor():
-		parent_state.change_state(jump_state)
+		main_state.change_state(jump_state)
 		return
 	
 	if Input.is_action_just_pressed("attack"):
-		player.rotation_component.rotate_towards_target = true
-		player.attack_component.thrust()
-		player.hitbox_component.enabled = false
+		parent_state.change_state(backstab_attack_state)
+		return
 	
 	if Input.is_action_just_pressed("block"):
-		parent_state.change_state(parry_state)
+		main_state.change_state(parry_state)
 		return
 	
 	if Input.is_action_pressed("block"):
-		parent_state.change_state(block_state)
+		main_state.change_state(block_state)
 		return
 	
 	
 	if not Globals.backstab_system.backstab_victim:
-		parent_state.transition_to_previous_state()
+		main_state.transition_to_previous_state()
 
 
 func process_movement_animations() -> void:
@@ -61,4 +62,4 @@ func process_movement_animations() -> void:
 
 
 func exit():
-	player.hitbox_component.enabled = true
+	pass

--- a/scripts/player/player_backstab_state/player_backstab_state.gd
+++ b/scripts/player/player_backstab_state/player_backstab_state.gd
@@ -1,0 +1,20 @@
+class_name PlayerBackstabState
+extends PlayerStateMachine
+
+@export var prepare_state: PlayerBackstabPrepareState
+@export var attack_state: PlayerBackstabAttackState
+
+func _ready():
+	super._ready()
+
+
+func enter():
+	change_state(prepare_state)
+
+func process_player():
+	if not player.attack_component.attacking and current_state == attack_state:
+		parent_state.change_state(parent_state.default_state)
+		return
+
+func exit():
+	pass

--- a/scripts/player/player_idle_state.gd
+++ b/scripts/player/player_idle_state.gd
@@ -17,9 +17,11 @@ var _locked_on_turning_in_place: bool = false
 
 func _ready():
 	super._ready()
-	
 	lock_on_system.lock_on.connect(_on_lock_on_system_lock_on)
 
+func enter():
+	player.rotation_component.move_direction = Vector3.ZERO
+	player.rotation_component.can_rotate = true
 
 func process_player() -> void:
 	if player.input_direction.length() > 0:


### PR DESCRIPTION
## Problems

1. After attack using backstab you can:
    - interupt it using dodge
    - move while after victim killed, but before animation ends.
    - sometimes you can miss when use backstab
    - spam attack cause weird behaviour
2. Moving using WASD while backstabing cause player to slide after it. Also true for dizzy finisher. ("can rotate" of rotation component keeps at false)

## Solution

Now backstab state splits into two substates:
- Prepare
- Attack
Prepare is previous backstab state besides attacking that moved to Attack state. So now we can't do anything in attack state.

Additionaly we resets some variables on enter Idle state which fixes problem 2. (Lazy but works)
