### PR TITLE
Feature: block checkpoint when enemy is aggro

### DIFF
--- a/scripts/components/notice_component/notice_component_aggro_state.gd
+++ b/scripts/components/notice_component/notice_component_aggro_state.gd
@@ -53,7 +53,7 @@ func enter() -> void:
 		.self_modulate\
 		.a = 0
 	
-	Globals.music_system.fade_to_active()
+	Globals.player.aggro_enemy_counter += 1
 
 
 func physics_process(delta) -> void:
@@ -113,4 +113,4 @@ func physics_process(delta) -> void:
 
 func exit() -> void:
 	_aggro_timer.stop()
-	Globals.music_system.fade_to_idle()
+	Globals.player.aggro_enemy_counter -= 1

--- a/scripts/entities/enemy.gd
+++ b/scripts/entities/enemy.gd
@@ -325,4 +325,4 @@ func _on_health_component_zero_health() -> void:
 		_character.hit_and_death_animations.death_1()
 	
 	if _blackboard.get_value("notice_state") == "aggro":
-		Globals.music_system.fade_to_idle()
+		Globals.player.aggro_enemy_counter -= 1

--- a/scripts/player/player_death_state.gd
+++ b/scripts/player/player_death_state.gd
@@ -55,6 +55,7 @@ func enter():
 	player.set_rotation_target_to_lock_on_target()
 	player.rotation_component.rotate_towards_target = false
 	
+	Globals.player._aggro_enemy_counter = 0
 	Globals.music_system.fade_out()
 
 

--- a/scripts/utilities/checkpoint.gd
+++ b/scripts/utilities/checkpoint.gd
@@ -54,7 +54,8 @@ func _physics_process(_delta: float) -> void:
 	if _player_inside:
 		if _player_angle < max_angle and \
 		not _previously_enabled_hint and \
-		_player.is_on_floor():
+		_player.is_on_floor() and \
+		_player.aggro_enemy_counter == 0:
 			can_sit_at_checkpoint = true
 			_checkpoint_system.enable_hint()
 			_previously_enabled_hint = true

--- a/scripts/utilities/music_system.gd
+++ b/scripts/utilities/music_system.gd
@@ -4,20 +4,20 @@ extends Node
 
 var idle_music: bool = true
 
-var _counter: int = 0:
-	set(value):
-		_counter = value
-		if _counter < 0:
-			_counter = 0
-
 @onready var idle_song: AudioStreamPlayer = $IdleBackgroundMusic
 @onready var active_song: AudioStreamPlayer = $ActiveBackgroundMusic
 @onready var anim: AnimationPlayer = $AnimationPlayer
 
+func _ready():
+	Globals.player.aggro_enemy_counter_changed.connect(on_counter_changed)
+
+func on_counter_changed(old_value, new_value):
+	if new_value > 0:
+		fade_to_active()
+	else:
+		fade_to_idle()
 
 func fade_to_active() -> void:
-	_counter += 1
-	
 	if not idle_music:
 		return
 	
@@ -26,12 +26,7 @@ func fade_to_active() -> void:
 
 
 func fade_to_idle() -> void:
-	_counter -= 1
-	
 	if idle_music:
-		return
-	
-	if _counter != 0:
 		return
 	
 	force_fade_to_idle()
@@ -49,7 +44,6 @@ func fade_out() -> void:
 		anim.play("ActiveFadeOut")
 	
 	idle_music = true
-	_counter = 0
 
 
 func reset() -> void:


### PR DESCRIPTION
## Desctiption
Now when enemy in aggro state player can not use checkpoints.
Also hint not showing when we near checkpoint.

## Implementation notes
Move aggro enemy counter from music to player because now checkpoints also use this information.
For now use "_aggro_enemy_counter" outside player script to 'silent' assigment(no signal call). May be exist some more correct way to deal with music fade out.