### PR TITLE
Fix enemy ignoring player when blocking

### DIFF
--- a/scripts/entities/enemy.gd
+++ b/scripts/entities/enemy.gd
@@ -248,6 +248,8 @@ func _on_entity_hitbox_weapon_hit(weapon: Sword) -> void:
 		
 		_instability_component.process_block()
 		
+		_notice_component.transition_to_aggro()
+		
 		_instability_component.enabled = false
 		_health_component.enabled = false
 		
@@ -272,6 +274,8 @@ func _on_entity_hitbox_weapon_hit(weapon: Sword) -> void:
 		
 		_character.parry_animations.parry()
 		_block_component.anim.play("parried")
+		
+		_notice_component.transition_to_aggro()
 		
 		_instability_component.process_parry()
 		


### PR DESCRIPTION
## Problem
When player attack enemy from back using common attacks and enemy blocks this he don`t react to player.
You can check it on enemy near 3rd checkpoint.

## Solution
Transit to aggro state when block or parry attack.