### PR TITLE
Fix health delay bar

### DIFF
--- a/scripts/components/health_component.gd
+++ b/scripts/components/health_component.gd
@@ -3,6 +3,7 @@ extends Node3D
 
 
 signal took_damage
+signal health_increased
 signal zero_health
 
 @export_category("Configuration")
@@ -12,7 +13,11 @@ signal zero_health
 @export var max_health: float = 100.0
 @export var health: float = max_health:
 	set(value):
-		health = clamp(value, 0.0, max_health)
+		var new_value = clamp(value, 0.0, max_health)
+		var old_value = health
+		health = new_value
+		if old_value < new_value:
+			health_increased.emit()
 
 @export_category("Particles")
 @export var blood_scene: PackedScene

--- a/scripts/user_interface/player_health_bar.gd
+++ b/scripts/user_interface/player_health_bar.gd
@@ -38,6 +38,11 @@ func _ready():
 			if _health_delay_timer.is_stopped():
 				_health_delay_timer.start()
 	)
+	_player.health_component.health_increased.connect(
+		func():
+			_delay_bar.scale.x = _get_health_bar_scale()
+			print(_get_health_bar_scale())
+	)
 	
 	_health_delay_timer = Timer.new()
 	_health_delay_timer.wait_time = _health_delay_pause
@@ -51,14 +56,7 @@ func _ready():
 
 
 func _process(_delta):
-	
-	_health = _player.health_component.health
-	
-	_health_bar.scale.x = lerp(
-		0.0, 
-		1.0,
-		_health / _default_health
-	)
+	_health_bar.scale.x = _get_health_bar_scale()
 	
 	if _play_delay:
 		_delay_bar.scale.x = move_toward(
@@ -69,3 +67,11 @@ func _process(_delta):
 	
 	if is_equal_approx(_delay_bar.scale.x, _health_bar.scale.x):
 		_play_delay = false
+
+func _get_health_bar_scale() -> float:
+	_health = _player.health_component.health
+	return lerp(
+		0.0, 
+		1.0,
+		_health / _default_health
+	)


### PR DESCRIPTION
## Problem
When we recover health and immediately get damage delay bar not recover with health bar.

## Solution
Set delay bar scale to health bar scale when we recover health.